### PR TITLE
AdVoid.DNS v1.1.169

### DIFF
--- a/AdVoid.DNS.txt
+++ b/AdVoid.DNS.txt
@@ -10,11 +10,11 @@
 ! {@!}
 ! Title: AdVoid.DNS
 ! Description: Blocks ads and trackers from ad servers
-! Version: 1.1.168
-! Last modified: 2022-10-07T23:28:00+0200
+! Version: 1.1.169
+! Last modified: 2022-10-07T23:50:00+0200
 ! Expires: 6 hours (update frequency)
 ! Homepage: https://github.com/igorskyflyer/ad-void
-! Entries: 1267
+! Entries: 1266
 ! Author: Igor Dimitrijević (@igorskyflyer)
 ! GitHub issues: https://github.com/igorskyflyer/ad-void/issues
 ! GitHub pull requests: https://github.com/igorskyflyer/ad-void/pulls
@@ -1248,7 +1248,6 @@
 ||multicsmorrice.com^
 ||passedofferundertake.com^
 ||banquetunarmedgrater.com^
-||joowkijejv.com^
 ||dictatepantry.com^
 ||0x01n2ptpuz3.com^
 ||driverpartially.com^


### PR DESCRIPTION
Removed 1 redundant rule, #6.