### PR TITLE
AdVoid.DNS v1.1.170

### DIFF
--- a/AdVoid.DNS.txt
+++ b/AdVoid.DNS.txt
@@ -10,11 +10,11 @@
 ! {@!}
 ! Title: AdVoid.DNS
 ! Description: Blocks ads and trackers from ad servers
-! Version: 1.1.169
-! Last modified: 2022-10-07T23:50:00+0200
+! Version: 1.1.170
+! Last modified: 2022-10-07T23:51:00+0200
 ! Expires: 6 hours (update frequency)
 ! Homepage: https://github.com/igorskyflyer/ad-void
-! Entries: 1266
+! Entries: 1265
 ! Author: Igor Dimitrijević (@igorskyflyer)
 ! GitHub issues: https://github.com/igorskyflyer/ad-void/issues
 ! GitHub pull requests: https://github.com/igorskyflyer/ad-void/pulls
@@ -1271,7 +1271,6 @@
 ||log.r2b2.io^
 ||adreactor.com^$third-party
 ||airdropemboil.com^
-||amazon-adsystem.com^
 ||clearbitscripts.com^
 ||flix360.io^$third-party
 ||logs.roku.com^


### PR DESCRIPTION
Removed 1 redundant rule, #6.