### PR TITLE
Add cap_html_filtering preprocessor check to HTML filtering rules

### DIFF
--- a/rules/scriptlets/privacy/html-filtering.txt
+++ b/rules/scriptlets/privacy/html-filtering.txt
@@ -1,1 +1,3 @@
+!#if cap_html_filtering
 *##^responseheader(report-to)
+!#endif


### PR DESCRIPTION
_Please review the [**Contributing Guidelines**](https://github.com/the-advoid/ad-void/blob/main/CONTRIBUTING.md) before submitting._  

<!--
    The initial checks are required.
    Pull requests that do not have all boxes checked may be closed or ignored.

    Please do not submit a PR without first reading the contributing guidelines.  
    
    Put an 'X' in between brackets to mark the task as completed.
-->
## Initial checks
- [x] I have read and followed the [**Contributing Guidelines**](https://github.com/the-advoid/ad-void/blob/main/CONTRIBUTING.md).
- [x] I understand that this PR may be declined or closed if it does not meet project requirements.

<!-- Provide a clear and concise description of the changes introduced by this pull request. -->
## Description

This fixes a bug within uBlock I only recently became aware of; uBlock doesn't check if Firefox is in use before allowing HTML filtering rules to be applied to the active rules during processing, these rules are redundant on Chromium based browsers, and do not need to be loaded for them; this pull request fixes that.

See: https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#html-filters

<!-- Link to the related issue(s) using keywords like "Fixes #123", "Closes #456". -->
## Related Issue
> Supported by uBO 1.15.0+ in Firefox 57+.

<!-- Select the type of the introduced change - one per pull request -->
## Type of Change
- [ ] 🧟‍♂️ **Anomaly** fix (*resolves a broken site caused by AdVoid*)
- [x] 🐛 **Malformation** fix (*corrects a malformed filter rule*)
- [ ] 🐞 **Candidate** addition (*adds a new URL/rule candidate*)
- [x] 🚀 **Optimization** (*makes AdVoid more efficient/compact*)
- [ ] ❌ **Removal** (*removes an outdated/false-positive rule*)
- [ ] 📖 **Documentation** update (*updates AdVoid's documentation*)
- [x] ⚡ **Other** (*please specify in Implementation Notes*)

<!-- Include context such as why this change is needed, and how it improves AdVoid. -->
## Implementation Notes

This change addresses the uBlock developers allowing HTML filtering rules to be applied on Chromium despite a lack of support; similarly to how they do not check to see if Chromium is in use before loading Permissions Policy injections.

<!-- Please do not modify the checklist below. -->
## Checklist for Reviewer
- [x] Code/rules follow the project's style and [**contribution guidelines**](https://github.com/the-advoid/ad-void/blob/main/CONTRIBUTING.md)
- [x] No new warnings or errors are introduced
- [x] Changes align with the related issue template (Anomaly, Candidate, etc.)
- [x] This PR correctly references the related issue(s) (Fixes # / Closes #)
